### PR TITLE
chore: update podspec with pinned dependencies and correct source url

### DIFF
--- a/ios/YouVersionReactNative.podspec
+++ b/ios/YouVersionReactNative.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :tvos => '17.0'
   }
   s.swift_version  = '5.9'
-  s.source         = { git: 'https://github.com/youversion/yvp-react-native-sdk' }
+  s.source         = { git: 'https://github.com/youversion/platform-sdk-reactnative' }
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'


### PR DESCRIPTION
The podspec needs to be pinned to specific versions of the Swift SDK. The RN SDK's release cycle could move differently than Swift's, so when the RN SDK is ready for a version bump, it will be manually done here.