### PR TITLE
YPE-1180 Add Android example app build tests

### DIFF
--- a/.github/workflows/android_example_test_build.yml
+++ b/.github/workflows/android_example_test_build.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test-android-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/android_example_test_build.yml
+++ b/.github/workflows/android_example_test_build.yml
@@ -1,0 +1,40 @@
+name: Test Android Example App Build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-android-build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install dependencies (root)
+        run: npm ci
+
+      - name: Install dependencies (example app)
+        working-directory: example
+        run: npm ci
+
+      - name: Prebuild Expo app
+        working-directory: example
+        run: npx expo prebuild --clean --platform android
+
+      - name: Build Android app
+        working-directory: example
+        run: npm run android -- --no-packager

--- a/.github/workflows/android_example_test_build.yml
+++ b/.github/workflows/android_example_test_build.yml
@@ -37,4 +37,4 @@ jobs:
 
       - name: Build Android app
         working-directory: example
-        run: npm run android -- --no-packager
+        run: npm run android

--- a/.github/workflows/android_example_test_build.yml
+++ b/.github/workflows/android_example_test_build.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test-android-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     

--- a/.github/workflows/android_example_test_build.yml
+++ b/.github/workflows/android_example_test_build.yml
@@ -36,5 +36,5 @@ jobs:
         run: npx expo prebuild --clean --platform android
 
       - name: Build Android app
-        working-directory: example
-        run: npm run android
+        working-directory: example/android
+        run: ./gradlew assembleDebug --no-daemon

--- a/.github/workflows/android_example_test_build.yml
+++ b/.github/workflows/android_example_test_build.yml
@@ -8,7 +8,6 @@ jobs:
   test-android-build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    runs-on: ubuntu-latest
     permissions:
       contents: read
     
@@ -37,8 +36,8 @@ jobs:
 
       - name: Prebuild Expo app
         working-directory: example
-        run: npx expo prebuild --clean --platform android
+        run: npx expo prebuild
 
       - name: Build Android app
         working-directory: example/android
-        run: ./gradlew assembleDebug --no-daemon
+        run: npm run android

--- a/.github/workflows/android_example_test_build.yml
+++ b/.github/workflows/android_example_test_build.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
 
       - name: Install dependencies (root)
         run: npm ci
@@ -40,4 +41,4 @@ jobs:
 
       - name: Build Android app
         working-directory: example/android
-        run: npm run android
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
## Description

We had broken example app builds. This adds the tests to build the Android app. 
## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [x] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `docs:` Documentation update
- [ ] `refactor:` Code refactoring (no functional changes)
- [ ] `perf:` Performance improvement
- [x] `test:` Test additions or updates
- [ ] `build:` Build system or dependency changes
- [x] `ci:` CI configuration changes
- [ ] `chore:` Other changes (maintenance, etc.)

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commit messages follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] I have updated the appropriate section in documentation (if needed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow that builds the Android example app on every PR targeting `main`, catching broken builds the way the existing `example_ios_build.yml` catches iOS regressions. The workflow is well-structured — it has an explicit `permissions: contents: read`, a 30-minute timeout, and leverages `setup-java`'s built-in Gradle caching, and correctly uses `./gradlew assembleDebug` directly from `example/android`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previous review concerns have been addressed and the only remaining finding is a minor P2 style suggestion.

The workflow correctly uses `./gradlew assembleDebug` from `example/android`, has explicit least-privilege permissions, a 30-minute timeout, and Gradle caching via `setup-java`. The sole remaining observation (missing `--platform android` on `expo prebuild`) is a non-blocking consistency suggestion that won't cause the workflow to fail on Ubuntu.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/android_example_test_build.yml | New workflow to build the Android example app on PRs to main; well-structured with timeout, least-privilege permissions, and Java/Gradle caching via setup-java, but `expo prebuild` is missing the `--platform android` flag. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant GH as GitHub Actions
    participant Ubuntu as ubuntu-latest runner
    participant Node as Node.js 20
    participant Java as Java 17 (Temurin)
    participant Expo as expo prebuild
    participant Gradle as Gradle (assembleDebug)

    PR->>GH: Triggered on PR to main
    GH->>Ubuntu: Spin up runner
    Ubuntu->>Ubuntu: Checkout repository
    Ubuntu->>Node: Setup Node.js 20 (npm cache)
    Ubuntu->>Java: Setup Java 17 (Gradle cache)
    Ubuntu->>Node: npm ci (root deps)
    Ubuntu->>Node: npm ci (example/ deps)
    Node->>Expo: npx expo prebuild
    Expo-->>Ubuntu: Generate example/android/ native project
    Ubuntu->>Gradle: ./gradlew assembleDebug
    Gradle-->>Ubuntu: Build APK (debug)
    Ubuntu-->>GH: Report success/failure
    GH-->>PR: Build status check
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/android_example_test_build.yml
Line: 39-40

Comment:
**Missing `--platform android` flag on `expo prebuild`**

Without `--platform android`, Expo will generate native files for all configured platforms (both `ios` and `android`). On Ubuntu this means it'll write out an `ios/` directory alongside `android/`, doing unnecessary work and diverging from the pattern in `example_ios_build.yml` which uses `--platform ios`.

```suggestion
        run: npx expo prebuild --platform android
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: cache and build"](https://github.com/youversion/platform-sdk-reactnative/commit/27f5e9e627e1cca7637ce4ba1d59d27bc78a94df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=21088160)</sub>

<!-- /greptile_comment -->